### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ def load_files(files):
     for fn in files:
         try:
             with open("docs/%s.rst" % fn) as f:
-                info[os.path.basename(fn)] = f.read()
+                info[os.path.basename(fn)] = f.read().splitlines()
         except IOError as err:  # NOQA
             print("Error when reading file '%s'" % fn)
             info[os.path.basename(fn)] = ""


### PR DESCRIPTION
Replacing f.read with f.read().splitlines() since its adding newline character which is causing to not get installed with latest setuptools 
With latest setuptools newline charecter is not allowed

ERROR: Command errored out with exit status 1:
   command: /usr/bin/python3.7 -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/home/ubuntu/PyDbLite/setup.py'"'"'; __file__='"'"'/home/ubuntu/PyDbLite/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-de9zg_16
       cwd: /home/ubuntu/PyDbLite/
  Complete output (29 lines):
  Error when reading file 'build/rst/pypi_description'
  running egg_info
  creating /tmp/pip-pip-egg-info-de9zg_16/PyDbLite.egg-info
  writing /tmp/pip-pip-egg-info-de9zg_16/PyDbLite.egg-info/PKG-INFO
  /usr/local/lib/python3.7/dist-packages/setuptools/dist.py:720: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
    % (opt, underscore_opt)
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/home/ubuntu/PyDbLite/setup.py", line 89, in <module>
      tests_require=['pytest'],
    File "/usr/local/lib/python3.7/dist-packages/setuptools/__init__.py", line 153, in setup
      return distutils.core.setup(**attrs)
    File "/usr/lib/python3.7/distutils/core.py", line 148, in setup
      dist.run_commands()
    File "/usr/lib/python3.7/distutils/dist.py", line 966, in run_commands
      self.run_command(cmd)
    File "/usr/lib/python3.7/distutils/dist.py", line 985, in run_command
      cmd_obj.run()
    File "/usr/local/lib/python3.7/dist-packages/setuptools/command/egg_info.py", line 292, in run
      writer(self, ep.name, os.path.join(self.egg_info, ep.name))
    File "/usr/local/lib/python3.7/dist-packages/setuptools/command/egg_info.py", line 656, in write_pkg_info
      metadata.write_pkg_info(cmd.egg_info)
    File "/usr/lib/python3.7/distutils/dist.py", line 1117, in write_pkg_info
      self.write_pkg_file(pkg_info)
    File "/usr/local/lib/python3.7/dist-packages/setuptools/dist.py", line 167, in write_pkg_file
      write_field('Summary', single_line(self.get_description()))
    **File "/usr/local/lib/python3.7/dist-packages/setuptools/dist.py", line 151, in single_line
      raise ValueError('Newlines are not allowed')
  ValueError: Newlines are not allowed**